### PR TITLE
Start to update Ghost 1.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ version: '2.1'
 
 services:
   ghost:
-    image: ghost:0.11.11
+    image: ghost:1.5.0
     volumes:
-      - ./content:/var/lib/ghost
+      - ./content:/var/lib/ghost/content
     ports:
       - 2368:2368
 


### PR DESCRIPTION
Update to ghost 1.5.0

1. My way to do it was go into old 0.11.11 Ghost
2. `docker-compose up ghost`
3. Then into Labs and then export your content.
4. `docker-compose down`
5. `mv content content-0.11`
6. `mkdir content`
7. Update docker-compose.yml to ghost 1.5.0 and new volume mount point
8. `docker-compose up ghost`
9. Go into Labs and then import content
10. Update casper theme to 1.4.0 and add Disqus block
