### PR TITLE
Update Ghost to 1.8.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   ghost:
-    image: ghost:1.5.0
+    image: ghost:1.8.2
     volumes:
       - ./content:/var/lib/ghost/content
     ports:


### PR DESCRIPTION
Lots of Ghost updates these last weeks.
A few bugs have been corrected since 1.5.0 (https://github.com/TryGhost/Ghost/releases), no impact on this project as far as in can tell.